### PR TITLE
Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.11-alpine
 RUN apk update && \
     apk upgrade && \
     apk add git


### PR DESCRIPTION
Build was failing due to issues with `go4.org/reflectutil` package. Using `golang:1.11-alpine` for the base Docker image fixes the issue.