### PR TITLE
Include resource_type definition in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,20 @@ see the [API documentation](https://developer.github.com/v3/repos/deployments/).
 ### Example
 
 ``` yaml
-- name: deployment
-  type: github-deployment
-  source:
-    user: BrandwatchLtd
-    repository: analytics
-    access_token: abcdef1234567890
+resource_types:
+  - name: github-deployment
+    type: docker-image
+    source:
+      repository: andyhume/github-deployment-resource
+      tag: "v0.8.0"
+      
+resources:
+  - name: deployment
+    type: github-deployment
+    source:
+      user: BrandwatchLtd
+      repository: analytics
+      access_token: abcdef1234567890
 ```
 
 ``` yaml


### PR DESCRIPTION
I don't know if I was just doing something way wrong but I had to define the custom resource type and it wasn't documented anywhere how I should do that. Some digging on docker hub yielded this and it seems to work.