### PR TITLE
Removes `status` from Version

### DIFF
--- a/in_command.go
+++ b/in_command.go
@@ -96,15 +96,9 @@ func (c *InCommand) Run(destDir string, request InRequest) (InResponse, error) {
 		return InResponse{}, err
 	}
 
-	latestStatus := ""
-	if len(statuses) > 0 {
-		latestStatus = *statuses[0].State
-	}
-
 	return InResponse{
 		Version: Version{
-			ID:       strconv.FormatInt(*deployment.ID, 10),
-			Statuses: latestStatus,
+			ID: strconv.FormatInt(*deployment.ID, 10),
 		},
 		Metadata: metadataFromDeployment(deployment, statuses),
 	}, nil

--- a/out_command.go
+++ b/out_command.go
@@ -58,15 +58,9 @@ func (c *OutCommand) Run(sourceDir string, request OutRequest) (OutResponse, err
 		return OutResponse{}, err
 	}
 
-	latestStatus := ""
-	if len(statuses) > 0 {
-		latestStatus = *statuses[0].State
-	}
-
 	return OutResponse{
 		Version: Version{
-			ID:       *request.Params.ID,
-			Statuses: latestStatus,
+			ID: *request.Params.ID,
 		},
 		Metadata: metadataFromDeployment(deployment, statuses),
 	}, nil

--- a/out_command_test.go
+++ b/out_command_test.go
@@ -110,8 +110,7 @@ var _ = Describe("Status Out Command", func() {
 
 				Ω(outResponse.Version).Should(Equal(
 					resource.Version{
-						ID:       "1234",
-						Statuses: "success",
+						ID: "1234",
 					},
 				))
 			})

--- a/resources.go
+++ b/resources.go
@@ -20,8 +20,7 @@ type Source struct {
 }
 
 type Version struct {
-	ID       string `json:"id"`
-	Statuses string `json:"status"`
+	ID string `json:"id"`
 }
 
 type CheckRequest struct {


### PR DESCRIPTION
Updating deployment status causes a new version of the resource to be
inserted by concourse and may trigger unwanted deployments.